### PR TITLE
Add crates 'specs' and 'specs-derive' to support ECS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+specs = "0.17.0"
+specs-derive = "0.4.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use specs_derive::Component;
 
 #[allow(dead_code)]
 struct State {
-    ecs: World
+    ecs: World,
 }
 
 #[allow(dead_code)]
@@ -19,12 +19,13 @@ mod test {
     fn test_ecs() {
         use super::*;
 
-        let mut gs = State {
-            ecs: World::new()
-        };
+        let mut gs = State { ecs: World::new() };
         gs.ecs.register::<Position>();
 
-        gs.ecs.create_entity().with(Position {x: 40, y: 25 }).build();
+        gs.ecs
+            .create_entity()
+            .with(Position { x: 40, y: 25 })
+            .build();
 
         let positions = gs.ecs.read_storage::<Position>();
         for pos in (&positions).join() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,35 @@
-pub fn add(x: i32, y: i32) -> i32 {
-    x + y
+use specs::prelude::*;
+use specs_derive::Component;
+
+#[allow(dead_code)]
+struct State {
+    ecs: World
+}
+
+#[allow(dead_code)]
+#[derive(Component)]
+struct Position {
+    x: i32,
+    y: i32,
 }
 
 #[cfg(test)]
 mod test {
     #[test]
-    fn test_add() {
+    fn test_ecs() {
         use super::*;
-        assert_eq!(add(3, 4), 7);
+
+        let mut gs = State {
+            ecs: World::new()
+        };
+        gs.ecs.register::<Position>();
+
+        gs.ecs.create_entity().with(Position {x: 40, y: 25 }).build();
+
+        let positions = gs.ecs.read_storage::<Position>();
+        for pos in (&positions).join() {
+            assert_eq!(pos.x, 40);
+            assert_eq!(pos.y, 25);
+        }
     }
 }


### PR DESCRIPTION
This revision includes:
- Add crates 'specs' and 'specs-derive' to support ECS
- Add simple test code to use crate 'specs'