### PR TITLE
Add card into ecs world

### DIFF
--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -16,10 +16,10 @@ pub struct Card {
     pub is_cur_hero: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Hero;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Minion {
     pub attack: u64,
     pub battlegrounds_premium_dbf_id: u64,

--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -16,10 +16,10 @@ pub struct Card {
     pub is_cur_hero: bool,
 }
 
-# [derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Hero;
 
-# [derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Minion {
     pub attack: u64,
     pub battlegrounds_premium_dbf_id: u64,
@@ -31,5 +31,5 @@ pub struct Minion {
     pub name: String,
     pub race: String,
     pub referenced_tags: Vec<String>,
-    pub tech_level: u8  
-} 
+    pub tech_level: u8,
+}

--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -15,3 +15,21 @@ pub struct Card {
 
     pub is_cur_hero: bool,
 }
+
+# [derive(Clone, Copy, Debug, PartialEq)]
+pub struct Hero;
+
+# [derive(Clone, Debug, PartialEq)]
+pub struct Minion {
+    pub attack: u64,
+    pub battlegrounds_premium_dbf_id: u64,
+    pub card_class: String,
+    pub dbf_id: u32,
+    pub health: u64,
+    pub id: String,
+    pub mechanics: Vec<String>,
+    pub name: String,
+    pub race: String,
+    pub referenced_tags: Vec<String>,
+    pub tech_level: u8  
+} 

--- a/src/loaders/card_loader.rs
+++ b/src/loaders/card_loader.rs
@@ -24,7 +24,7 @@ impl CardLoader {
         let display: Display = path.display();
 
         // Open the path in read-only mode, returns `io::Result<File>`
-        let mut file: File = match File::open(&path) {
+        let mut file: File = match File::open(path) {
             Err(why) => panic!("couldn't open {}: {}", display, why),
             Ok(file) => file,
         };

--- a/src/loaders/card_to_entity.rs
+++ b/src/loaders/card_to_entity.rs
@@ -1,0 +1,80 @@
+mod json_reader;
+mod components;
+
+use legion::*;
+use crate::json_reader::*;
+use crate::components::card::Minion;
+
+
+fn main() {
+
+    let cards = card_container();
+    let mut world = World::default();
+
+    for card in cards {
+        let attack = if card.attack.is_some() {
+            card.attack.unwrap()
+        } else{
+            0
+        };
+        let battlegrounds_premium_dbf_id = card.battlegrounds_premium_dbf_id.unwrap();
+        let card_class = if card.card_class.is_none() {
+            ""
+        } else {
+            card.card_class.as_deref().unwrap()
+        };
+        let dbf_id = card.dbf_id;
+        let health = if card.health.is_some() { 
+            card.health.unwrap()
+         } else {
+            0
+        };
+        let id = card.id;
+        let mechanics = if card.mechanics.is_none() {
+            Vec::new()
+        } else {
+            card.mechanics.unwrap()
+        };
+        let name = card.name;
+        let race = if card.race.is_some() {
+            card.race.as_deref().unwrap()
+        } else {
+            ""
+        };
+        let referenced_tags = if card.referenced_tags.is_none() {
+            Vec::new()
+        } else {
+            card.referenced_tags.unwrap()
+        };
+        let tech_level = if card.tech_level.is_some() {
+            card.tech_level.unwrap()
+        } else {
+            0
+        };
+
+        let _ = world.push(
+            (
+                Minion {
+                    attack,
+                    battlegrounds_premium_dbf_id,
+                    card_class: String::from(card_class),
+                    dbf_id,
+                    health,
+                    id: String::from(id),
+                    mechanics,
+                    name: String::from(name),
+                    race: String::from(race),
+                    referenced_tags,
+                    tech_level
+                },
+            )
+        );
+
+    }
+
+    let mut query = <&Minion>::query();
+    for minion in query.iter(&world) {
+        println!("{:?}", minion.name);
+    }
+}
+

--- a/src/loaders/json_reader.rs
+++ b/src/loaders/json_reader.rs
@@ -28,7 +28,7 @@ struct Card {
     r#type: String,
 }
 
-fn main() {
+pub fn card_container() -> Vec<Card> {
     let path = Path::new("res/cards_kor.json");
     let file = File::open(path).expect("file not found");
     let mut cards = Vec::new();
@@ -37,9 +37,9 @@ fn main() {
     
     for card in raw_cards.iter() {
         if card.battlegrounds_premium_dbf_id.is_some() {
-            cards.push(card)
+            cards.push(card.clone())
         }
     }
-    println!("{}", cards.len());
+    cards
 }
 


### PR DESCRIPTION
This revision includes:
- Change function name of  'json_reader.rs' and the return type of it
- Add a new file 'card_to_entity' which pushes every battleground cards into entity world
- Add 'Here' and 'Minion' components in 'components/card.rs'